### PR TITLE
Adds support for anthrocon_plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ workspace.xml
 tasks.xml
 distribute-*.tar.gz
 *.swp
+anthrocon_plugin/

--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -49,6 +49,18 @@ else
 fi
 
 ################################################################################
+# Add Anthrocon Plugin
+################################################################################
+
+if [ -d /home/vagrant/magfest/anthrocon_plugin ]; then
+    ln -s /home/vagrant/magfest/anthrocon_plugin /home/vagrant/sideboard/plugins/anthrocon_plugin
+else
+    cd /home/vagrant/sideboard/plugins/
+    git clone https://github.com/Anthrocon-Reg/anthrocon_plugin
+    cd /home/vagrant
+fi
+
+################################################################################
 # Set up the Sideboard virtualenv and install our dependencies
 ################################################################################
 


### PR DESCRIPTION
Updates the vagrant install file to pull down anthrocon_plugin from
GitHub and add it as a plugin. It will alternatively use a local copy if
you have it cloned inside your ubersystem/ folder.
